### PR TITLE
Fix Mutalisk morph

### DIFF
--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
@@ -10,23 +10,16 @@ public class Mutalisk extends MobileUnit implements Organic, Armed {
         super(id, UnitType.Zerg_Mutalisk);
     }
 
-    public boolean morph(UnitType type) {
-        if (type == UnitType.Zerg_Guardian) {
-            return morphGuardian();
-        }
-        if (type == UnitType.Zerg_Defiler) {
-            return morphDevourer();
-        }
-        return false;
+    public boolean morph(final UnitType unitType) {
+        return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, unitType.getId());
     }
 
     public boolean morphGuardian() {
-
-        return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, UnitType.Zerg_Guardian.getId());
+        return morph(UnitType.Zerg_Guardian);
     }
 
     public boolean morphDevourer() {
-        return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, UnitType.Zerg_Devourer.getId());
+        return morph(UnitType.Zerg_Devourer);
     }
 
     @Override

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Mutalisk.java
@@ -15,7 +15,7 @@ public class Mutalisk extends MobileUnit implements Organic, Armed {
             return morphGuardian();
         }
         if (type == UnitType.Zerg_Defiler) {
-            return morphDefiler();
+            return morphDevourer();
         }
         return false;
     }
@@ -25,8 +25,8 @@ public class Mutalisk extends MobileUnit implements Organic, Armed {
         return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, UnitType.Zerg_Guardian.getId());
     }
 
-    public boolean morphDefiler() {
-        return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, UnitType.Zerg_Defiler.getId());
+    public boolean morphDevourer() {
+        return issueCommand(this.id, UnitCommandType.Morph.ordinal(), -1, -1, -1, UnitType.Zerg_Devourer.getId());
     }
 
     @Override


### PR DESCRIPTION
The original fix seen in https://github.com/Bytekeeper/BWAPI4J/commit/ae7f07a15e94443d556a33b89dc69913ccac6064 is much appreciated. However, Mutalisks cannot morph into Defilers. This new PR uses the Devourer `UnitType` as well as refactors the morph method. The purpose of the refactor is to remove any requirement for `if` or `switch` statements.