### PR TITLE
BWAPI4J: Revert OOB checks in "BWMapImpl.isWalkable()"

### DIFF
--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/BWMapImpl.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/BWMapImpl.java
@@ -46,10 +46,7 @@ class BWMapImpl implements BWMap {
     }
 
     public boolean isWalkable(int walkX, int walkY) {
-        return walkX >= 0 && walkY >= 0 &&
-                walkX < width * TilePosition.SIZE_IN_PIXELS / WalkPosition.SIZE_IN_PIXELS &&
-                walkY < height * TilePosition.SIZE_IN_PIXELS / WalkPosition.SIZE_IN_PIXELS &&
-                this.walkabilityInfo[walkX][walkY] == 1;
+        return this.walkabilityInfo[walkX][walkY] == 1;
     }
 
     @Override


### PR DESCRIPTION
I highly recommend not checking for invalid input parameters in this case. Any out of bounds index for the walkabilityInfo array (e.g. walkX = -20, walkY = 56004, etc.) will be thrown as an exception without the checks. With the checks, potential bugs may be hidden in the caller's code. For example, why is the caller checking if WalkPosition (-20, 56004) is walkable? That WalkPosition does not exist. It is not up to `isWalkable(int,int)` to handle invalid input parameters.