### PR TITLE
BWAPI4J: Remove generic from class "Worker" definition

### DIFF
--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Drone.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Drone.java
@@ -3,7 +3,7 @@ package org.openbw.bwapi4j.unit;
 import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 
-public class Drone extends Worker<Extractor> implements Organic, Burrowable {
+public class Drone extends Worker implements Organic, Burrowable {
 
     private boolean burrowed;
 

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Probe.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Probe.java
@@ -4,7 +4,7 @@ import org.openbw.bwapi4j.Position;
 import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 
-public class Probe extends Worker<Assimilator> implements Mechanical, Robotic {
+public class Probe extends Worker implements Mechanical, Robotic {
 
 
     protected Probe(int id) {

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SCV.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/SCV.java
@@ -6,7 +6,7 @@ import org.openbw.bwapi4j.TilePosition;
 import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 
-public class SCV extends Worker<Refinery> implements Mechanical {
+public class SCV extends Worker implements Mechanical {
 
 	private static final Logger logger = LogManager.getLogger();
 	

--- a/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Worker.java
+++ b/BWAPI4J/src/main/java/org/openbw/bwapi4j/unit/Worker.java
@@ -1,11 +1,10 @@
 package org.openbw.bwapi4j.unit;
 
-import org.openbw.bwapi4j.Position;
 import org.openbw.bwapi4j.TilePosition;
 import org.openbw.bwapi4j.type.UnitCommandType;
 import org.openbw.bwapi4j.type.UnitType;
 
-public abstract class Worker<R extends GasMiningFacility> extends MobileUnit implements Armed {
+public abstract class Worker extends MobileUnit implements Armed {
     private boolean isConstructing;
     private boolean isGatheringGas;
     private boolean isGatheringMinerals;
@@ -79,12 +78,12 @@ public abstract class Worker<R extends GasMiningFacility> extends MobileUnit imp
         return issueCommand(this.id, UnitCommandType.Return_Cargo.ordinal(), -1, -1, -1, queued ? 1 : 0);
     }
 
-    public boolean gather(R gasMiningFacility) {
+    public boolean gather(GasMiningFacility gasMiningFacility) {
 
         return issueCommand(this.id, UnitCommandType.Gather.ordinal(), gasMiningFacility.getId(), -1, -1, 0);
     }
 
-    public boolean gather(R gasMiningFacility, boolean shiftQueueCommand) {
+    public boolean gather(GasMiningFacility gasMiningFacility, boolean shiftQueueCommand) {
 
         return issueCommand(this.id, UnitCommandType.Gather.ordinal(), gasMiningFacility.getId(), -1, -1,
                 shiftQueueCommand ? 1 : 0);


### PR DESCRIPTION
I like your addition of the `Worker` class! As discussed in https://github.com/OpenBW/BWAPI4J/issues/10, removing the generic attribute from the class definition should now allow workers to mine from different gas mining facilities.